### PR TITLE
fix error: Ambiguous method overloading for method java.io.File#<init>.

### DIFF
--- a/src/main/groovy/com/tencent/bugly/gradle/BuglyPlugin.groovy
+++ b/src/main/groovy/com/tencent/bugly/gradle/BuglyPlugin.groovy
@@ -527,6 +527,9 @@ class BuglyPlugin implements Plugin<Project> {
         }
         SymtabToolAndroid.main(args)
         String symtabFileName = SymtabToolAndroid.getSymtabFileName()
+        if (null == symtabFileName) {
+            return null
+        }
         return new File(symtabFileName)
     }
 


### PR DESCRIPTION
```
Cannot resolve which method to invoke for [null] due to overlapping prototypes between:
    [class java.lang.String]
    [class java.net.URI]
```
